### PR TITLE
Add delete marker

### DIFF
--- a/database/create_schema.sql
+++ b/database/create_schema.sql
@@ -7,6 +7,7 @@ create table claim (
   created_by  varchar(50) not null,
   upload_time datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   partner_name varchar(50),
+  mark_for_delete boolean DEFAULT false,
   primary key (id)
 );
 


### PR DESCRIPTION
This field is added to mark the records corresponding to the claim results to be deleted (by some K8s Jobs when the test result tables would grow substantially). Kept for future development.