### PR TITLE
Add makefile and mysql related paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+MYSQL_PV_PATH = ./k8s/mysql-pv.yaml
+MYSQL_DEPLOYMENT_PATH = ./k8s/mysql-deployment.yaml
+
+deploy-mysql:
+	oc apply -f ${MYSQL_PV_PATH}
+	oc apply -f ${MYSQL_DEPLOYMENT_PATH}
+
+delete-mysql:
+	oc delete -f ${MYSQL_DEPLOYMENT_PATH}
+	oc delete -f ${MYSQL_PV_PATH}


### PR DESCRIPTION
Adds a simple `Makefile` with paths for deploying and deleting mysql and it's resources:
- `make deploy-mysql`
- `make delete-mysql`