### PR TITLE
Satisfy the makefile linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ MYSQL_PV_PATH = ./k8s/mysql-pv.yaml
 MYSQL_DEPLOYMENT_PATH = ./k8s/mysql-deployment.yaml
 COLLECTOR_DEPLOYMENT_PATH = ./k8s/collector-deployment.yml
 
+.PHONY: deploy-mysql delete-mysql deploy-collector delete-collector lint all clean test
+
 deploy-mysql:
 	oc apply -f ${MYSQL_PV_PATH}
 	oc apply -f ${MYSQL_DEPLOYMENT_PATH}


### PR DESCRIPTION
Prior to this change, `make lint` would show:

```
$ make lint
checkmake Makefile
    RULE              DESCRIPTION             FILE NAME   LINE NUMBER  
                                                                       
  minphony   Missing required phony target    Makefile    0            
             "all"                                                     
  minphony   Missing required phony target    Makefile    0            
             "clean"                                                   
  minphony   Missing required phony target    Makefile    0            
             "test"                                                    
make: *** [lint] Error 
```

These paths are still empty but the linter is happy.